### PR TITLE
Decode HttpResponse as Success only if code is 2XX

### DIFF
--- a/src/main/scala/com/msilb/scalandav20/client/OandaApiClient.scala
+++ b/src/main/scala/com/msilb/scalandav20/client/OandaApiClient.scala
@@ -46,15 +46,8 @@ class OandaApiClient(env: Environment, authToken: String) extends HttpRequestSer
 
   private def sendReceive[T <: Response : Decoder](req: HttpRequest): Future[GenericResponse[T]] = {
     execute(req).flatMap {
-      case r if Set[StatusCode](
-        BadRequest,
-        Unauthorized,
-        Forbidden,
-        NotFound,
-        MethodNotAllowed,
-        RequestedRangeNotSatisfiable
-      ).contains(r.status) => Unmarshal(r.entity).to[ErrorResponse].map(Left(_))
-      case r => Unmarshal(r.entity).to[T].map(Right(_))
+      case r if r.status.isSuccess() => Unmarshal(r.entity).to[T].map(Right(_))
+      case r => Unmarshal(r.entity).to[ErrorResponse].map(Left(_))
     }
   }
 


### PR DESCRIPTION
I think we should try to decode the  HttpReponse with Circe only if the response have been successful. 
For instance, the server answered me "GatewayTimeout" (504), and the current behavior tried to decode it and failed because of the field "instrument" was not present. So it throw a DecodingFailure which sucks.
I think this commit should solve most of these problem!